### PR TITLE
Version bumped to 0.0.3, synced with version at RubyGems

### DIFF
--- a/lib/protected_form/version.rb
+++ b/lib/protected_form/version.rb
@@ -1,3 +1,3 @@
 module ProtectedForm
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/vendor/assets/javascripts/protected_form.js
+++ b/vendor/assets/javascripts/protected_form.js
@@ -21,7 +21,7 @@
   }
 
   //Form Submit
-  function sendProtectedForm() {
+  function sendProtectedForm(event) {
     // looking for closest .js-protected-form block
     var container = this;
     do {
@@ -40,6 +40,10 @@
 
     // and than trigger submit for this form
     form.dispatchEvent(submitEvent);
+    if (event) {
+      // Prevent double submit event
+      event.preventDefault();
+    }
     return false;
   }
 


### PR DESCRIPTION
Retrieved version 0.0.3 code from [Rubygems](https://rubygems.org/gems/protected_form), since the [repository](https://github.com/KELiON/protected_form) didn't have it (with latest featured version being 0.0.2).
