### PR TITLE
JS rework

### DIFF
--- a/vendor/assets/javascripts/protected_form.js
+++ b/vendor/assets/javascripts/protected_form.js
@@ -3,15 +3,15 @@
   var matches;
 
   (function(doc) {
-     matches =
-        doc.matchesSelector ||
-        doc.webkitMatchesSelector ||
-        doc.mozMatchesSelector ||
-        doc.oMatchesSelector ||
-        doc.msMatchesSelector;
+    matches =
+      doc.matchesSelector ||
+      doc.webkitMatchesSelector ||
+      doc.mozMatchesSelector ||
+      doc.oMatchesSelector ||
+      doc.msMatchesSelector;
   })(document.documentElement);
 
-  // simple implementation of $(document).delegate
+  // Simple implementation of $(document).delegate
   function delegate(event, selector, callback) {
     document.addEventListener(event, function(e){
       if (matches.call(e.target, selector)) {
@@ -21,29 +21,22 @@
   }
 
   //Form Submit
-  function sendProtectedForm(event) {
-    // looking for closest .js-protected-form block
+  function sendProtectedForm() {
+    // Looking for closest .js-protected-form block
     var container = this;
     do {
       container = container.parentNode;
     }
     while (!container.className.match('js-protected-form'));
     var form = document.getElementById(container.id + '_form').firstChild;
-    var submitEvent = new Event('submit', {
-      'bubbles'    : true,
-      'cancelable' : true
-    });
 
-    // change html structure: return content into form
-    container.parentNode.insertBefore(form, container[0]);
+    // Change html structure: return content into form
+    container.parentNode.insertBefore(form, container);
     form.firstChild.appendChild(container);
 
-    // and than trigger submit for this form
-    form.dispatchEvent(submitEvent);
-    if (event) {
-      // Prevent double submit event
-      event.preventDefault();
-    }
+    // Fix for IE when using certain versions of pjax libraries and losing focus
+    document.body.focus();
+
     return false;
   }
 


### PR DESCRIPTION
Simplified code.
- No need for custom event (hence compatibility with IE)
- No early 'double submit with pjax' issue found...
- ...hence no issue with need to double click the Submit button to submit non-pjax form (that was a result of fixing 'double submit with pjax' issue)

Tested in Win7+IE9; Win7+IE11; Mac+Chrome48; Mac+Safari9; Mac+FireFox43 in both pjax and non-pjax forms (with [pjax_rails 0.4.0](https://github.com/rails/pjax_rails/releases/tag/v0.4.0)).

If this is accepted, #2 should be closed in favour of this one.
