### PR TITLE
JS fix to support updated Rails Form Helpers

### DIFF
--- a/lib/protected_form/version.rb
+++ b/lib/protected_form/version.rb
@@ -1,3 +1,3 @@
 module ProtectedForm
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/vendor/assets/javascripts/protected_form.js
+++ b/vendor/assets/javascripts/protected_form.js
@@ -20,7 +20,7 @@
     });
   }
 
-  //Form Submit
+  // Form Submit
   function sendProtectedForm() {
     // Looking for closest .js-protected-form block
     var container = this;
@@ -32,7 +32,7 @@
 
     // Change html structure: return content into form
     container.parentNode.insertBefore(form, container);
-    form.firstChild.appendChild(container);
+    form.appendChild(container);
 
     // Fix for IE when using certain versions of pjax libraries and losing focus
     document.body.focus();


### PR DESCRIPTION
Rails form helpers doesn't contain additional `<div style="margin:0;padding:0">` container any more, thus leading to improper work of the JS in some cases.

Rails 4.0.3 form helper output:
![01](https://cloud.githubusercontent.com/assets/1061406/13785331/3d7cb110-eae4-11e5-86de-c319c35d4dbf.png)

Rails 4.2.4 form helper output:
![02](https://cloud.githubusercontent.com/assets/1061406/13785365/538c1702-eae4-11e5-80ed-5115058350a1.png)
